### PR TITLE
Remove `SetupCard`

### DIFF
--- a/src/SlamData/Workspace/Card/API/Component.purs
+++ b/src/SlamData/Workspace/Card/API/Component.purs
@@ -62,8 +62,6 @@ eval q =
   case q of
     NC.EvalCard info output next ->
       pure next
-    NC.SetupCard _ next ->
-      pure next
     NC.NotifyRunCard next ->
       pure next
     NC.NotifyStopCard next ->

--- a/src/SlamData/Workspace/Card/APIResults/Component.purs
+++ b/src/SlamData/Workspace/Card/APIResults/Component.purs
@@ -83,7 +83,6 @@ evalCard q =
       for (info.input >>= Lens.preview Port._VarMap) \varMap →
         H.modify (_ { varMap = varMap })
       pure next
-    NC.SetupCard _ next -> pure next
     NC.NotifyRunCard next -> pure next
     NC.NotifyStopCard next -> pure next
     NC.Save k -> pure $ k J.jsonEmptyObject

--- a/src/SlamData/Workspace/Card/Ace/Component.purs
+++ b/src/SlamData/Workspace/Card/Ace/Component.purs
@@ -19,7 +19,6 @@ module SlamData.Workspace.Card.Ace.Component
   , AceDSL
   , AceHTML
   , AceEval
-  , AceSetup
   , module SlamData.Workspace.Card.Ace.Component.Query
   , module SlamData.Workspace.Card.Ace.Component.State
   ) where
@@ -41,7 +40,7 @@ import SlamData.Workspace.Card.Ace.Component.Query (QueryP)
 import SlamData.Workspace.Card.Ace.Component.State (StateP)
 import SlamData.Workspace.Card.Ace.Model as Model
 import SlamData.Workspace.Card.CardType (CardType(Ace), AceMode, aceMode)
-import SlamData.Workspace.Card.Common.EvalQuery (CardEvalQuery(..), CardEvalInput, CardSetupInfo)
+import SlamData.Workspace.Card.Common.EvalQuery (CardEvalQuery(..), CardEvalInput)
 import SlamData.Workspace.Card.Component (CardStateP, CardQueryP, makeCardComponent, makeQueryPrism, _AceState, _AceQuery)
 import SlamData.Effects (Slam)
 import SlamData.Render.CSS as CSS
@@ -50,12 +49,10 @@ import Utils.Ace (getRangeRecs, readOnly)
 
 type AceDSL = H.ParentDSL Unit AceState CardEvalQuery AceQuery Slam Unit
 type AceHTML = H.ParentHTML AceState CardEvalQuery AceQuery Slam Unit
-type AceSetup = CardSetupInfo -> AceDSL Unit
 type AceEval = CardEvalInput -> AceDSL Unit
 
 type AceConfig =
   { mode :: AceMode
-  , setup :: AceSetup
   , eval :: AceEval
   }
 
@@ -92,7 +89,6 @@ aceComponent cfg = makeCardComponent
     --content <- fromMaybe "" <$> H.query unit (H.request GetText)
     --result <- evaluator info content
     --pure $ k result
-  eval (SetupCard input next) = cfg.setup input $> next
   eval (Save k) = do
     content <- fromMaybe "" <$> H.query unit (H.request GetText)
     mbEditor <- H.query unit (H.request GetEditor)

--- a/src/SlamData/Workspace/Card/Chart/Component.purs
+++ b/src/SlamData/Workspace/Card/Chart/Component.purs
@@ -89,7 +89,6 @@ eval (ECH.EvalCard value output next) = do
     _ → do
       H.query unit $ H.action HECH.Clear
       pure next
-eval (ECH.SetupCard _ next) = pure next
 -- No state needs loading/saving for the chart card, as it is fully populated
 -- by its input, and will be restored by the parent `Viz` card running when
 -- the deck is restored

--- a/src/SlamData/Workspace/Card/Common/EvalQuery.purs
+++ b/src/SlamData/Workspace/Card/Common/EvalQuery.purs
@@ -16,7 +16,6 @@ limitations under the License.
 
 module SlamData.Workspace.Card.Common.EvalQuery
   ( CardEvalQuery(..)
-  , CardSetupInfo
   , liftWithCanceler
   , liftWithCanceler'
   , liftWithCancelerP
@@ -34,11 +33,8 @@ import Halogen (ParentDSL, ComponentDSL)
 import Halogen.Component.Utils as Hu
 
 import SlamData.Effects (Slam, SlamDataEffects)
-import SlamData.Workspace.Card.CardId as CID
 import SlamData.Workspace.Card.Eval.CardEvalT (CardEvalInput, CardEvalResult, CardEvalT, runCardEvalT, temporaryOutputResource)
 import SlamData.Workspace.Card.Port as Port
-
-import Utils.Path (DirPath)
 
 -- | The query algebra shared by the inner parts of a card component.
 -- |
@@ -47,28 +43,16 @@ import Utils.Path (DirPath)
 -- |   continuation for the evaluation result to be returned to.
 -- |         TODO: update these notes -js
 -- |
--- | - `SetupCard` is will be called when the card is being added as a linked
--- |   card from another, passing through the current input port value so the
--- |   current card can set its state based on that. Used to pull a VarMap
--- |   through for autocomplete purposes, or for the search card to be able to
--- |   auto-select the parent card's result set as the resource, etc.
 -- | - `NotifyRunCard` allows the card to notify the deck that it should be
 -- |   run - the card cannot run itself directly.
 data CardEvalQuery a
   = EvalCard CardEvalInput (Maybe Port.Port) a -- (CardEvalResult → a)
-  | SetupCard CardSetupInfo a
   | NotifyRunCard a
   | NotifyStopCard a
   | SetCanceler (Canceler SlamDataEffects) a
   | Save (Json → a)
   | Load Json a
   | SetDimensions { width ∷ Number, height ∷ Number } a
-
-type CardSetupInfo =
-  { path ∷ Maybe DirPath
-  , input ∷ Port.Port
-  , cardId ∷ CID.CardId
-  }
 
 liftWithCancelerP
   ∷ ∀ a state slot innerQuery innerState

--- a/src/SlamData/Workspace/Card/Component.purs
+++ b/src/SlamData/Workspace/Card/Component.purs
@@ -173,7 +173,6 @@ makeCardComponentPart def render =
 
   cardEvalPeek ∷ ∀ a. CQ.CardEvalQuery a → CardDSL Unit
   cardEvalPeek (CQ.SetCanceler canceler _) = H.modify $ CS._canceler .~ canceler
-  cardEvalPeek (CQ.SetupCard _ _) = H.modify $ CS._canceler .~ mempty
   cardEvalPeek (CQ.EvalCard _ _ _) = H.modify $ CS._canceler .~ mempty
   cardEvalPeek (CQ.NotifyStopCard _) = stopRun
   cardEvalPeek _ = pure unit

--- a/src/SlamData/Workspace/Card/Download/Component.purs
+++ b/src/SlamData/Workspace/Card/Download/Component.purs
@@ -81,13 +81,6 @@ cardEval (Ec.NotifyRunCard next) = pure next
 cardEval (Ec.NotifyStopCard next) = pure next
 cardEval (Ec.Save k) = pure $ k jsonEmptyObject
 cardEval (Ec.Load json next) = pure next
-cardEval (Ec.SetupCard { input } next) = do
-  case input of
-    P.DownloadOptions opts → do
-      handleDownloadPort opts
-      pure unit
-    _ → pure unit
-  pure next
 cardEval (Ec.SetCanceler _ next) = pure next
 cardEval (Ec.SetDimensions _ next) = pure next
 

--- a/src/SlamData/Workspace/Card/DownloadOptions/Component.purs
+++ b/src/SlamData/Workspace/Card/DownloadOptions/Component.purs
@@ -129,9 +129,6 @@ cardEval (Ec.NotifyRunCard next) = pure next
 cardEval (Ec.NotifyStopCard next) = pure next
 cardEval (Ec.Save k) = map (k ∘ encode) H.get
 cardEval (Ec.Load json next) = for_ (decode json) H.set $> next
-cardEval (Ec.SetupCard {input} next) = do
-  H.modify $ _source .~ preview P._Resource input
-  pure next
 cardEval (Ec.SetCanceler _ next) = pure next
 cardEval (Ec.SetDimensions _ next) = pure next
 

--- a/src/SlamData/Workspace/Card/Draftboard/Component.purs
+++ b/src/SlamData/Workspace/Card/Draftboard/Component.purs
@@ -126,7 +126,6 @@ render opts state =
 
 evalCard ∷ Natural Ceq.CardEvalQuery DraftboardDSL
 evalCard (Ceq.EvalCard input output next) = pure next
-evalCard (Ceq.SetupCard info next) = pure next
 evalCard (Ceq.NotifyRunCard next) = pure next
 evalCard (Ceq.NotifyStopCard next) = pure next
 evalCard (Ceq.SetCanceler canceler next) = pure next

--- a/src/SlamData/Workspace/Card/Error/Component.purs
+++ b/src/SlamData/Workspace/Card/Error/Component.purs
@@ -66,11 +66,7 @@ cardEval ∷ CEQ.CardEvalQuery ~> DSL
 cardEval q =
   case q of
     CEQ.EvalCard {input} output next → do
-      H.modify ∘ Lens.set ECS._message $
-        input ^? Lens._Just ∘ Port._CardError
-      pure next
-    CEQ.SetupCard {input} next → do
-      H.modify ∘ Lens.set ECS._message $ input ^? Port._CardError
+      H.modify ∘ Lens.set ECS._message $ input ^? Lens._Just ∘ Port._CardError
       pure next
     CEQ.NotifyRunCard next →
       pure next

--- a/src/SlamData/Workspace/Card/Factory.purs
+++ b/src/SlamData/Workspace/Card/Factory.purs
@@ -21,7 +21,7 @@ import SlamData.Prelude
 
 import Data.Argonaut as J
 
-import SlamData.Workspace.Card.Ace.Component (AceSetup, AceEval, aceComponent)
+import SlamData.Workspace.Card.Ace.Component (AceEval, aceComponent)
 import SlamData.Workspace.Card.API.Component (apiComponent)
 import SlamData.Workspace.Card.APIResults.Component (apiResultsComponent)
 import SlamData.Workspace.Card.CardId (CardId)
@@ -37,7 +37,7 @@ import SlamData.Workspace.Card.JTable.Component (jtableComponent)
 import SlamData.Workspace.Card.Markdown.Component (markdownComponent)
 import SlamData.Workspace.Card.Next.Component (nextCardComponent)
 import SlamData.Workspace.Card.OpenResource.Component (openResourceComponent)
-import SlamData.Workspace.Card.Query.Eval (querySetup, queryEval)
+import SlamData.Workspace.Card.Query.Eval (queryEval)
 import SlamData.Workspace.Card.Save.Component (saveCardComponent)
 import SlamData.Workspace.Card.Search.Component (searchComponent)
 import SlamData.Workspace.Card.Viz.Component (vizComponent)
@@ -48,7 +48,6 @@ cardTypeComponent ty cid inner opts =
     Ace mode →
       aceComponent
         { mode
-        , setup: aceSetupMode mode
         , eval: aceEval mode
         }
     Search → searchComponent
@@ -65,10 +64,6 @@ cardTypeComponent ty cid inner opts =
     DownloadOptions → DOpts.comp
     ErrorCard → Error.comp
     Draftboard -> draftboardComponent opts
-
-aceSetupMode ∷ AceMode → AceSetup
-aceSetupMode MarkdownMode = \_ → pure unit
-aceSetupMode SQLMode = querySetup
 
 aceEval ∷ AceMode → AceEval
 aceEval MarkdownMode = \_ → pure unit

--- a/src/SlamData/Workspace/Card/JTable/Component.purs
+++ b/src/SlamData/Workspace/Card/JTable/Component.purs
@@ -70,7 +70,6 @@ evalCard =
       for_ info.input \port →
         CEQ.runCardEvalT $ runTable port $> port
       pure next
-    CEQ.SetupCard _ next → pure next
     CEQ.Save k → pure ∘ k =<< H.gets (Model.encode ∘ JTS.toModel)
     CEQ.Load json next → do
       either (const (pure unit)) H.set $ JTS.fromModel <$> Model.decode json

--- a/src/SlamData/Workspace/Card/Markdown/Component.purs
+++ b/src/SlamData/Workspace/Card/Markdown/Component.purs
@@ -123,7 +123,6 @@ evalCEQ (EvalCard info output next) = do
     H.modify (_ { input = Just sd })
     void $ H.query unit $ H.action (SD.SetDocument sd)
   pure next
-evalCEQ (SetupCard _ next) = pure next
 evalCEQ (Save k) = do
   input ← fromMaybe mempty <$> H.gets _.input
   state ← fromMaybe SM.empty <$> H.query unit (H.request SD.GetFormState)

--- a/src/SlamData/Workspace/Card/Next/Component.purs
+++ b/src/SlamData/Workspace/Card/Next/Component.purs
@@ -122,7 +122,6 @@ cardEval (Ec.NotifyRunCard next) = pure next
 cardEval (Ec.NotifyStopCard next) = pure next
 cardEval (Ec.Save k) = pure $ k jsonEmptyObject
 cardEval (Ec.Load _ next) = pure next
-cardEval (Ec.SetupCard p next) = pure next
 cardEval (Ec.SetCanceler _ next) = pure next
 cardEval (Ec.SetDimensions _ next) = pure next
 

--- a/src/SlamData/Workspace/Card/OpenResource/Component.purs
+++ b/src/SlamData/Workspace/Card/OpenResource/Component.purs
@@ -147,7 +147,6 @@ cardEval (Eq.Load js next) = do
       R.File fp → resourceSelected res
       _ → pure unit
   pure next
-cardEval (Eq.SetupCard info next) = pure next
 cardEval (Eq.SetCanceler _ next) = pure next
 cardEval (Eq.SetDimensions _ next) = pure next
 cardEval (Eq.NotifyStopCard next) = pure next

--- a/src/SlamData/Workspace/Card/Save/Component.purs
+++ b/src/SlamData/Workspace/Card/Save/Component.purs
@@ -100,9 +100,10 @@ cardEval (Eq.Save k) = do
 cardEval (Eq.Load js next) = do
   for_ (decodeJson js) \s → H.modify (_pathString .~ s)
   pure next
-cardEval (Eq.SetupCard p next) = do
-  H.modify (_pathString .~ (Pt.printPath $ Eq.temporaryOutputResource p))
-  pure next
+-- TODO: move something equivalent to this into EvalCard -gb
+-- cardEval (Eq.SetupCard p next) = do
+--   H.modify (_pathString .~ (Pt.printPath $ Eq.temporaryOutputResource p))
+--   pure next
 cardEval (Eq.SetCanceler _ next) = pure next
 cardEval (Eq.SetDimensions _ next) = pure next
 

--- a/src/SlamData/Workspace/Card/Search/Component.purs
+++ b/src/SlamData/Workspace/Card/Search/Component.purs
@@ -81,8 +81,6 @@ cardEval q =
   case q of
     NC.EvalCard input output next →
       pure next
-    NC.SetupCard _ next →
-      pure next
     NC.NotifyRunCard next →
       pure next
     NC.NotifyStopCard next →

--- a/src/SlamData/Workspace/Card/Viz/Component.purs
+++ b/src/SlamData/Workspace/Card/Viz/Component.purs
@@ -285,7 +285,6 @@ cardEval (EvalCard info output next) = do
   -- data takes place exterinallyin the model eval machinery.
   H.modify $ VCS._loading .~ false
   pure next
-cardEval (SetupCard _ next) = pure next
 cardEval (NotifyRunCard next) = pure next
 cardEval (NotifyStopCard next) = pure next
 cardEval (Save k) = do

--- a/src/SlamData/Workspace/Component.purs
+++ b/src/SlamData/Workspace/Component.purs
@@ -92,20 +92,18 @@ render state =
     Loading →
       HH.div [ HP.classes [ workspaceClass ] ]
         []
-
-    Ready →
-      HH.div [ HP.classes [ workspaceClass ] ]
-        [ HH.slot' cpDeck unit \_ →
-           { component: Deck.comp
-           , initialState: Deck.initialState
-           }
-        ]
-
     Error err →
       HH.div [ HP.classes [ B.alert, B.alertDanger ] ]
         [ HH.h1
             [ HP.class_ B.textCenter ]
             [ HH.text err ]
+        ]
+    _ →
+      HH.div [ HP.classes [ workspaceClass ] ]
+        [ HH.slot' cpDeck unit \_ →
+           { component: Deck.comp
+           , initialState: Deck.initialState
+           }
         ]
 
   shouldHideTopMenu ∷ Boolean

--- a/src/SlamData/Workspace/Deck/Component.purs
+++ b/src/SlamData/Workspace/Deck/Component.purs
@@ -481,21 +481,8 @@ createCard cardType = do
       H.modify $ DCS.addCard cardType J.jsonEmptyObject
     Just cardId → do
       (st × newCardId) ← H.gets $ DCS.addCard' cardType J.jsonEmptyObject
-
       setDeckState st
-      input ← map join $ H.query' cpCard (CardSlot cardId) $ left (H.request GetOutput)
-      for_ input \input' → do
-        path ← H.gets DCS.deckPath
-        let setupInfo = { path, input: input', cardId: newCardId }
-        void
-          $ H.query' cpCard  (CardSlot newCardId)
-          $ right
-          $ H.ChildF unit
-          $ left
-          $ H.action (CEQ.SetupCard setupInfo)
-
       runCard newCardId
-
   updateIndicatorAndNextAction
   triggerSave
 


### PR DESCRIPTION
This no longer needs to exist as something distinct from `EvalCard` since we run the deck forwards from the point of a new card after adding it anyway, which amounts to the same thing as what `SetupCard` was used for.

There are some special cases that may need restoring that I've commented out for now, but I don't think they were contributing anything meaningful anyway, since all the tests that used to pass still pass without this.